### PR TITLE
replaced deprecated set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/actions/build-python-image/action.yml
+++ b/.github/actions/build-python-image/action.yml
@@ -63,9 +63,9 @@ runs:
         if [[ ${{ inputs.dirty_tag == 'true' }} ]]; then
           OLD_TAG="${{ inputs.version }}"
           TAG=$(echo ${OLD_TAG} | sed 's/+/-/g')
-          echo "::set-output name=tag::$TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=tag::${{ inputs.version }}"
+          echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
         fi
     - name: Push
       shell: bash


### PR DESCRIPTION
warning appeared https://github.com/anna-money/anna-tax-admin/actions/runs/7029267606

<img width="888" alt="image" src="https://github.com/anna-money/workflow-bionic-beaver/assets/5162965/7c9a0ee3-53ae-4dae-bc1e-89a08831995d">

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples