### PR TITLE
Have supported dev tag for the initial commit for setuptools>=69.0.0

### DIFF
--- a/.github/actions/get-dev-tag/action.yml
+++ b/.github/actions/get-dev-tag/action.yml
@@ -15,4 +15,4 @@ runs:
     - name: Get git tag
       shell: bash
       id: dev-tag
-      run: echo "tag=$(git describe --tags --long --dirty | sed -E 's/(.*)-(.*)-(.*)/\1.dev\2+\3/')" >> $GITHUB_OUTPUT
+      run: git describe --tags --long --dirty; if [ $? = 0 ]; then echo "tag=$(git describe --tags --long --dirty | sed -E 's/(.*)-(.*)-(.*)/\1.dev\2+\3/')" >> $GITHUB_OUTPUT; else echo "tag=0.0.dev0+$(git describe --tags --long --dirty --always)" >> $GITHUB_OUTPUT; fi;

--- a/.github/actions/get-dev-tag/action.yml
+++ b/.github/actions/get-dev-tag/action.yml
@@ -15,4 +15,4 @@ runs:
     - name: Get git tag
       shell: bash
       id: dev-tag
-      run: echo "tag=$(git describe --tags --long --dirty | sed -E 's/(.*)-(.*)-(.*)/\1.dev\2+\3/')" >> $GITHUB_OUTPUT || echo "tag=0.0.dev0+$(git describe --tags --long --dirty --always)" >> $GITHUB_OUTPUT
+      run: if git describe --tags --long --dirty ; then echo "tag=$(git describe --tags --long --dirty | sed -E 's/(.*)-(.*)-(.*)/\1.dev\2+\3/')" >> $GITHUB_OUTPUT; else echo "tag=0.0.dev0+$(git describe --tags --long --dirty --always)" >> $GITHUB_OUTPUT; fi;

--- a/.github/actions/get-dev-tag/action.yml
+++ b/.github/actions/get-dev-tag/action.yml
@@ -15,4 +15,4 @@ runs:
     - name: Get git tag
       shell: bash
       id: dev-tag
-      run: git describe --tags --long --dirty; if [ $? = 0 ]; then echo "tag=$(git describe --tags --long --dirty | sed -E 's/(.*)-(.*)-(.*)/\1.dev\2+\3/')" >> $GITHUB_OUTPUT; else echo "tag=0.0.dev0+$(git describe --tags --long --dirty --always)" >> $GITHUB_OUTPUT; fi;
+      run: echo "tag=$(git describe --tags --long --dirty | sed -E 's/(.*)-(.*)-(.*)/\1.dev\2+\3/')" >> $GITHUB_OUTPUT || echo "tag=0.0.dev0+$(git describe --tags --long --dirty --always)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_dev_artefacts.yml
+++ b/.github/workflows/build_dev_artefacts.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - id: dev-tag
-        uses: anna-money/workflow-bionic-beaver/.github/actions/get-dev-tag@master
+        uses: anna-money/workflow-bionic-beaver/.github/actions/get-dev-tag@tech/tech/setuptools-69.0.0
 
   build_lib:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_dev_artefacts.yml
+++ b/.github/workflows/build_dev_artefacts.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - id: dev-tag
-        uses: anna-money/workflow-bionic-beaver/.github/actions/get-dev-tag@tech/tech/setuptools-69.0.0
+        uses: anna-money/workflow-bionic-beaver/.github/actions/get-dev-tag@master
 
   build_lib:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The new version of the `setuptools` library no longer supports the empty version. It means we need to get the dev tag more intelligently.